### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.1

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -1,2 +1,5 @@
 ["0.2.0"]
 git-tree-sha1 = "0904f9e2a87ab9013a3dbcca89ecf6567241029e"
+
+["0.2.1"]
+git-tree-sha1 = "2c65cb1d19ab56c6753994c66c9cbdf44b8ffd59"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: 2c65cb1d19ab56c6753994c66c9cbdf44b8ffd59

Registrator tree SHA: 3dd9eaa965a2925b0a34d994b4d886d797f54b20