### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.2

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "0904f9e2a87ab9013a3dbcca89ecf6567241029e"
 
 ["0.2.1"]
 git-tree-sha1 = "2c65cb1d19ab56c6753994c66c9cbdf44b8ffd59"
+
+["0.2.2"]
+git-tree-sha1 = "76f7a8687f0d701495228233714ab49ce539b3c6"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: 76f7a8687f0d701495228233714ab49ce539b3c6

Registrator tree SHA: 3dd9eaa965a2925b0a34d994b4d886d797f54b20