### PR TITLE
New version: PopSimIBX v0.2.0

### DIFF
--- a/P/PopSimIBX/Deps.toml
+++ b/P/PopSimIBX/Deps.toml
@@ -1,3 +1,7 @@
 [0]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+["0.2-0"]
+PopSimBase = "e60d1b08-a48f-4b5c-9e89-ad4b39d64fb4"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/P/PopSimIBX/Versions.toml
+++ b/P/PopSimIBX/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "0ee584ccfae256cd5a72d1a70619e1e07904933d"
 
 ["0.1.3"]
 git-tree-sha1 = "c4f852bf1da8cd15dd21e44232e99ebd4a580268"
+
+["0.2.0"]
+git-tree-sha1 = "6bae60a213050862ef9d6b3424b0e1b91b4eace4"


### PR DESCRIPTION
UUID: 88d7705d-7f72-40d5-8927-d9bc8cbe062a
Repo: git@github.com:ArndtLab/PopSimIBX.jl.git
Tree: 6bae60a213050862ef9d6b3424b0e1b91b4eace4

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1