### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.3

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -6,3 +6,6 @@ git-tree-sha1 = "2c65cb1d19ab56c6753994c66c9cbdf44b8ffd59"
 
 ["0.2.2"]
 git-tree-sha1 = "76f7a8687f0d701495228233714ab49ce539b3c6"
+
+["0.2.3"]
+git-tree-sha1 = "eb2ba482dfcaf40e2125be6acf224acca0e6dcbb"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: eb2ba482dfcaf40e2125be6acf224acca0e6dcbb

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1