### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.5

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "eb2ba482dfcaf40e2125be6acf224acca0e6dcbb"
 
 ["0.2.4"]
 git-tree-sha1 = "1af1701d17572cb3bf43b1232dc9631dfcc81711"
+
+["0.2.5"]
+git-tree-sha1 = "0cee557a091c59017d80e1d0e6722ff59bb35292"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: 0cee557a091c59017d80e1d0e6722ff59bb35292

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1