### PR TITLE
New package: NotebookHelper v0.1.4

### DIFF
--- a/N/NotebookHelper/Deps.toml
+++ b/N/NotebookHelper/Deps.toml
@@ -1,0 +1,4 @@
+[0]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/N/NotebookHelper/Package.toml
+++ b/N/NotebookHelper/Package.toml
@@ -1,0 +1,3 @@
+name = "NotebookHelper"
+uuid = "b0dc253a-7593-4df9-8537-7a9abf73c7af"
+repo = "git@github.molgen.mpg.de:ArndtLab/NotebookHelper.jl.git"

--- a/N/NotebookHelper/Versions.toml
+++ b/N/NotebookHelper/Versions.toml
@@ -1,0 +1,2 @@
+["0.1.4"]
+git-tree-sha1 = "62942f3fdb2feb82db4ae1ca33867e0aeb0bdb11"

--- a/Registry.toml
+++ b/Registry.toml
@@ -11,6 +11,7 @@ repo = "git@github.com:ArndtLab/JuliaRegistry.git"
 50651ce3-0423-45d2-b99c-8ea4267d2717 = { name = "DemoInfer", path = "D/DemoInfer" }
 815cba6c-817c-4129-96fa-0a4c55d2f473 = { name = "PopSimOtherTools", path = "P/PopSimOtherTools" }
 88d7705d-7f72-40d5-8927-d9bc8cbe062a = { name = "PopSimIBX", path = "P/PopSimIBX" }
+b0dc253a-7593-4df9-8537-7a9abf73c7af = { name = "NotebookHelper", path = "N/NotebookHelper" }
 ba2eccb5-91b3-48f8-94f3-77bebdceebef = { name = "GenomicCoordinates", path = "G/GenomicCoordinates" }
 be701e70-f25e-4246-ad85-09b5c637c424 = { name = "MariuxUtils", path = "M/MariuxUtils" }
 cac4bed1-6c8c-4dbe-be0d-c63a427c1233 = { name = "MLDs", path = "M/MLDs" }


### PR DESCRIPTION
UUID: b0dc253a-7593-4df9-8537-7a9abf73c7af
Repo: git@github.molgen.mpg.de:ArndtLab/NotebookHelper.jl.git
Tree: 62942f3fdb2feb82db4ae1ca33867e0aeb0bdb11

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1