### PR TITLE
New version: MariuxUtils v0.2.5

### DIFF
--- a/M/MariuxUtils/Versions.toml
+++ b/M/MariuxUtils/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.19"]
 git-tree-sha1 = "90a056dd7020964fd4de4b0425d837afb8f82d06"
+
+["0.2.5"]
+git-tree-sha1 = "e8ca3ca2141488e9f1b3e5bb4d25165d243a2a92"


### PR DESCRIPTION
UUID: be701e70-f25e-4246-ad85-09b5c637c424
Repo: git@github.molgen.mpg.de:ArndtLab/MariuxUtils.jl.git
Tree: e8ca3ca2141488e9f1b3e5bb4d25165d243a2a92

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1