### PR TITLE
New version: NotebookHelper v0.1.5

### DIFF
--- a/N/NotebookHelper/Versions.toml
+++ b/N/NotebookHelper/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.4"]
 git-tree-sha1 = "62942f3fdb2feb82db4ae1ca33867e0aeb0bdb11"
+
+["0.1.5"]
+git-tree-sha1 = "1a88f67353c69db62f8b157112b9c68f74377c74"


### PR DESCRIPTION
UUID: b0dc253a-7593-4df9-8537-7a9abf73c7af
Repo: git@github.molgen.mpg.de:ArndtLab/NotebookHelper.jl.git
Tree: 1a88f67353c69db62f8b157112b9c68f74377c74

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1