### PR TITLE
New version: MariuxUtils v0.2.6

### DIFF
--- a/M/MariuxUtils/Compat.toml
+++ b/M/MariuxUtils/Compat.toml
@@ -1,0 +1,2 @@
+["0.2.6 - 0"]
+ElasticClusterManager = "1"

--- a/M/MariuxUtils/Deps.toml
+++ b/M/MariuxUtils/Deps.toml
@@ -1,6 +1,11 @@
 [0]
-ClusterManagers = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+["0 - 0.2.5"]
+ClusterManagers = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
+
+["0.2.6 - 0"]
+ElasticClusterManager = "547eee1f-27c8-4193-bfd6-9e092c8e3331"

--- a/M/MariuxUtils/Versions.toml
+++ b/M/MariuxUtils/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "90a056dd7020964fd4de4b0425d837afb8f82d06"
 
 ["0.2.5"]
 git-tree-sha1 = "e8ca3ca2141488e9f1b3e5bb4d25165d243a2a92"
+
+["0.2.6"]
+git-tree-sha1 = "024b6c7caec28b7799ce7b5cd4255285811fbc8c"


### PR DESCRIPTION
UUID: be701e70-f25e-4246-ad85-09b5c637c424
Repo: git@github.molgen.mpg.de:ArndtLab/MariuxUtils.jl.git
Tree: 024b6c7caec28b7799ce7b5cd4255285811fbc8c

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1