### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.6

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "1af1701d17572cb3bf43b1232dc9631dfcc81711"
 
 ["0.2.5"]
 git-tree-sha1 = "0cee557a091c59017d80e1d0e6722ff59bb35292"
+
+["0.2.6"]
+git-tree-sha1 = "b6423eb39a55cfe69d978f8d386c6ad30dda6171"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: b6423eb39a55cfe69d978f8d386c6ad30dda6171

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1