### PR TITLE
New version: ArndtLabJuliaRegistryTools v0.2.9

### DIFF
--- a/A/ArndtLabJuliaRegistryTools/Versions.toml
+++ b/A/ArndtLabJuliaRegistryTools/Versions.toml
@@ -21,3 +21,6 @@ git-tree-sha1 = "b6423eb39a55cfe69d978f8d386c6ad30dda6171"
 
 ["0.2.7"]
 git-tree-sha1 = "1d8b1bf38beafbd15b241cc7859ac5c182c384ee"
+
+["0.2.9"]
+git-tree-sha1 = "4b8ba415828d9d0b29ee96eab1e447e048535a66"


### PR DESCRIPTION
UUID: d7f3587b-5de0-4757-a92e-3c842e241000
Repo: git@github.com:ArndtLab/ArndtLabJuliaRegistryTools.git
Tree: 4b8ba415828d9d0b29ee96eab1e447e048535a66

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1