### PR TITLE
New version: Cached v0.5.0

### DIFF
--- a/C/Cached/Versions.toml
+++ b/C/Cached/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "cbf20787997623a3b9cc044260aeb7faba238cec"
 
 ["0.4.1"]
 git-tree-sha1 = "3e6c8438a06c951ba24fc4e9f0efa705f0b59190"
+
+["0.5.0"]
+git-tree-sha1 = "e49284bb6999db8659becd5ae94b7027542af9f6"


### PR DESCRIPTION
UUID: 43ffbea4-38f1-43a5-9bfb-671206d3a474
Repo: https://github.com/ArndtLab/Cached.jl.git
Tree: e49284bb6999db8659becd5ae94b7027542af9f6

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1