### PR TITLE
New version: MariuxUtils v0.2.8

### DIFF
--- a/M/MariuxUtils/Compat.toml
+++ b/M/MariuxUtils/Compat.toml
@@ -1,5 +1,8 @@
 ["0.2.6"]
 ElasticClusterManager = "1"
 
-["0.2.7 - 0"]
-Reexport = "1.2.2 - 1"
+["0.2.7-0"]
+Reexport = "1.2.2-1"
+
+["0.2.8-0"]
+ThreadPinning = "1.1.1-1"

--- a/M/MariuxUtils/Deps.toml
+++ b/M/MariuxUtils/Deps.toml
@@ -4,11 +4,14 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-["0 - 0.2.5"]
+["0-0.2.5"]
 ClusterManagers = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
 
-["0.2.6 - 0"]
+["0.2.6-0"]
 ElasticClusterManager = "547eee1f-27c8-4193-bfd6-9e092c8e3331"
 
-["0.2.7 - 0"]
+["0.2.7-0"]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
+["0.2.8-0"]
+ThreadPinning = "811555cd-349b-4f26-b7bc-1f208b848042"

--- a/M/MariuxUtils/Versions.toml
+++ b/M/MariuxUtils/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "024b6c7caec28b7799ce7b5cd4255285811fbc8c"
 
 ["0.2.7"]
 git-tree-sha1 = "b8d87065403b8cbe9a6b0304d7f47098897eafe3"
+
+["0.2.8"]
+git-tree-sha1 = "2ba033fc776152e914be40c69871cccb6e2e9db7"


### PR DESCRIPTION
UUID: be701e70-f25e-4246-ad85-09b5c637c424
Repo: git@github.molgen.mpg.de:ArndtLab/MariuxUtils.jl.git
Tree: 2ba033fc776152e914be40c69871cccb6e2e9db7

Registrator tree SHA: c887ec1a5f4fe2872dfa01640a1dd2050fac48f4