### PR TITLE
New version: MariuxUtils v0.2.10

### DIFF
--- a/M/MariuxUtils/Versions.toml
+++ b/M/MariuxUtils/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "b8d87065403b8cbe9a6b0304d7f47098897eafe3"
 
 ["0.2.8"]
 git-tree-sha1 = "2ba033fc776152e914be40c69871cccb6e2e9db7"
+
+["0.2.10"]
+git-tree-sha1 = "566fcbd6827111379879112890c1ec89d5162854"


### PR DESCRIPTION
UUID: be701e70-f25e-4246-ad85-09b5c637c424
Repo: git@github.molgen.mpg.de:ArndtLab/MariuxUtils.jl.git
Tree: 566fcbd6827111379879112890c1ec89d5162854

Registrator tree SHA: c887ec1a5f4fe2872dfa01640a1dd2050fac48f4