### PR TITLE
New version: IBSpector v0.12.3

### DIFF
--- a/I/IBSpector/Versions.toml
+++ b/I/IBSpector/Versions.toml
@@ -96,3 +96,6 @@ git-tree-sha1 = "275fc0e14250f9416048485bbfb5204d2dca99d4"
 
 ["0.12.2"]
 git-tree-sha1 = "21cfc72ec7f1a56a3c2de518b3b5e84d2cb1baca"
+
+["0.12.3"]
+git-tree-sha1 = "bdc9e99923c76992f52f689a0765552f7d065042"


### PR DESCRIPTION
UUID: 50651ce3-0423-45d2-b99c-8ea4267d2717
Repo: https://github.com/ArndtLab/IBSpector.jl.git
Tree: bdc9e99923c76992f52f689a0765552f7d065042

Registrator tree SHA: 3087a02cf7baffe55fc5d26573bfd9ab8833c613