### PR TITLE
New version: IBSpector v0.12.5

### DIFF
--- a/I/IBSpector/Versions.toml
+++ b/I/IBSpector/Versions.toml
@@ -102,3 +102,6 @@ git-tree-sha1 = "bdc9e99923c76992f52f689a0765552f7d065042"
 
 ["0.12.4"]
 git-tree-sha1 = "117fe3d6ecf8193af8b490ffacd4dae61fc01bbc"
+
+["0.12.5"]
+git-tree-sha1 = "8458d5f1420c377ca2a2b726ead4abbc7861f537"


### PR DESCRIPTION
UUID: 50651ce3-0423-45d2-b99c-8ea4267d2717
Repo: https://github.com/ArndtLab/IBSpector.jl.git
Tree: 8458d5f1420c377ca2a2b726ead4abbc7861f537

Registrator tree SHA: 3087a02cf7baffe55fc5d26573bfd9ab8833c613